### PR TITLE
[bug] fix opendrive2lanelet-convert output path

### DIFF
--- a/src/map_srv.rs
+++ b/src/map_srv.rs
@@ -59,6 +59,8 @@ impl MapConverter {
         } = Command::new("opendrive2lanelet-convert")
             .arg("-f")
             .arg(&self.input_path)
+            .arg("-o")
+            .arg("/dev/stdout")
             .output()
             .with_context(|| err(""))?;
 


### PR DESCRIPTION
The original map services will respond empty data to client, which is discovered by my teammates.
We have traced the code and found that there may have some bug.

The original service use ```opendrive2lanelet-convert``` to convert the map; however, the converted result is not used, and stdout (which is empty) is passed to client as the response.

By default, the converted result of ```opendrive2lanelet-convert``` would be saved to a file located at the same directory with "xml" file extension. I added additional args "-o /dev/stdout" to redirect the converted result to stdout so that the rest of the code remains intact.