### PR TITLE
fix: supply osm flag when running opendrive2lanelet-convert

### DIFF
--- a/src/map_srv.rs
+++ b/src/map_srv.rs
@@ -61,6 +61,8 @@ impl MapConverter {
             .arg(&self.input_path)
             .arg("-o")
             .arg("/dev/stdout")
+            .arg("--osm")
+            .arg("+proj=utm +zone=32 +ellps=WGS84")
             .output()
             .with_context(|| err(""))?;
 


### PR DESCRIPTION
The map service returns a map in the format of *CommonRoad* but not *Lanelet2*, which is due to the lack of "--osm" flag when executing `opendrive2lanelet-convert`. This bug is fixed by adding this flag with default projection parameters which can be found in [the github repository of opendrive2lanelet](https://github.com/usdot-fhwa-stol/opendrive2lanelet/blob/e3e79a713c6b91f89536f7f69afe3cb51fb707f7/opendrive2lanelet/osm/osm.py?fbclid=IwAR2ZTsI0o2eIGOWpvJp08DItHoV1k_PRpJyYafFujZAB3P_miF_j2oUKzsw#L14).